### PR TITLE
ScanNetwork bug fix

### DIFF
--- a/Arduino_package/hardware/libraries/WiFi/examples/ScanNetworks/ScanNetworks.ino
+++ b/Arduino_package/hardware/libraries/WiFi/examples/ScanNetworks/ScanNetworks.ino
@@ -24,6 +24,8 @@ void setup() {
         ; // wait for serial port to connect. Needed for native USB port only
     }
 
+    // check for WiFi status:
+    status = WiFi.status();
     // Print WiFi MAC address:
     printMacAddress();
 }


### PR DESCRIPTION
Add `WiFi.status();` to initialize the Wi-Fi driver and prevent Wi-Fi unable to scan bug