### PR TITLE
Bump version of arduino/compile-sketches action in workflow

### DIFF
--- a/.github/workflows/CI_compile_examples.yml
+++ b/.github/workflows/CI_compile_examples.yml
@@ -75,7 +75,7 @@ jobs:
             Arduino_zip_libraries
 
       - name: Compile examples dev
-        uses: arduino/compile-sketches@v1.1.0
+        uses: arduino/compile-sketches@v1.1.1
         with:
           fqbn: realtek:AmebaPro2:${{ matrix.board.fqbn }}
           sketch-paths: |
@@ -94,7 +94,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/dev' || github.event.pull_request.base.ref == 'dev'}}
 
       - name: Compile examples main
-        uses: arduino/compile-sketches@v1.1.0
+        uses: arduino/compile-sketches@v1.1.1
         with:
           fqbn: realtek:AmebaPro2:${{ matrix.board.fqbn }}
           sketch-paths: |


### PR DESCRIPTION
## Description of Change

The "CI Compile Examples" GitHub Actions workflow uses the [**arduino/compile-sketches**](https://github.com/arduino/compile-sketches) action to compile the project's Arduino sketches that demonstrate the usage of the bundled libraries.

A new release has been made of the **arduino/compile-sketches** action which fixes a bug that was causing spurious failures of the workflow runs (https://github.com/arduino/compile-sketches/issues/284):

https://github.com/ambiot/ambpro2_arduino/actions/runs/9494502295/job/26164974307#step:4:312

```text
Traceback (most recent call last):
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 1717, in <module>
    main()  # pragma: no cover
    ^^^^^^
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 63, in main
    compile_sketches.compile_sketches()
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 219, in compile_sketches
    self.install_platforms()
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 334, in install_platforms
    self.install_platforms_from_path(platform_list=platform_list.path)
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 522, in install_platforms_from_path
    platform_installation_path = self.get_platform_installation_path(platform=platform)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/_actions/arduino/compile-sketches/v1.1.0/compilesketches/compilesketches.py", line 563, in get_platform_installation_path
    if installed_platform[self.cli_json_key("core list", "ID")] == platform[self.dependency_name_key]:
       ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```

Previously, the workflow pinned the action to the version that had the bug so it is necessary to bump the pin in order to get the fixed version of the action.

## Tests and Environments 

Run the workflow.

## Remark related links

https://github.com/arduino/compile-sketches/issues/284