### PR TITLE
Fix library name

### DIFF
--- a/.github/release_commit_log.txt
+++ b/.github/release_commit_log.txt
@@ -1,12 +1,8 @@
 Feature:
-- Add BMI270 examples
-- Add Http Upload Image examples
-- Add Infrared and Ambient Light Sensor Features
-- Add Ollama LLM example and multithreading example
+- Add Add Websocket Viewer example
 
 API Updates:
-- Add API for camera status check
-- Update AUTO_PWM for Ambient Light Sensor API
 
 Misc:
-- Add Workflow to find and summarise hardware library ".h" functions
+- Update code base for websocket
+- fix multithreading library name

--- a/Arduino_package/hardware/libraries/Multithreading/examples/Multithreading/Multithreading.ino
+++ b/Arduino_package/hardware/libraries/Multithreading/examples/Multithreading/Multithreading.ino
@@ -7,7 +7,7 @@
     - thread B: prints "executing thread b" every 2000ms
 
   Example guide:
-  TBD
+  https://ameba-doc-arduino-sdk.readthedocs-hosted.com/en/latest/ameba_pro2/amb82-mini/Example_Guides/Multithreading/Multithreading.html
 */
 
 char BUFFER[1024];

--- a/Arduino_package/hardware/libraries/Multithreading/library.properties
+++ b/Arduino_package/hardware/libraries/Multithreading/library.properties
@@ -1,4 +1,4 @@
-name=Ameba
+name=AmebaMultithreading
 version=1.0.0
 author=Realtek SG
 maintainer=Realtek SG


### PR DESCRIPTION
## Description of Change
- Feature:
- API Updates:
- Misc: fix multithreading library name

## Tests and Environments 
- AMB82-mini
- ambpro2_arduino V4.1.0
- Arduino IDE 2.3.6
- Ubuntu 22.04
