### PR TITLE
Fix object detection image example

### DIFF
--- a/Arduino_package/hardware/libraries/NeuralNetwork/examples/ObjectDetectionImage/ObjectDetectionImage.ino
+++ b/Arduino_package/hardware/libraries/NeuralNetwork/examples/ObjectDetectionImage/ObjectDetectionImage.ino
@@ -14,7 +14,7 @@ char filelist_name[] = "image_list.txt";    // modify according to image name li
 void setup()
 {
     Serial.begin(115200);
-    ObjDetImg.modelSelect(OBJECT_DETECTION, DEFAULT_YOLOV4TINY, NA_MODEL, NA_MODEL);
+    ObjDetImg.modelSelect(OBJECT_DETECTION, DEFAULT_YOLOV7TINY, NA_MODEL, NA_MODEL);
     ObjDetImg.begin(filelist_name);
 }
 

--- a/Arduino_package/hardware/libraries/NeuralNetwork/src/NNObjectDetectionImage.cpp
+++ b/Arduino_package/hardware/libraries/NeuralNetwork/src/NNObjectDetectionImage.cpp
@@ -225,25 +225,29 @@ int NNObjectDetectionImage::ImageDecodeToRGB888planar_ConvertInPlace(void *pbuff
         return -1;
     }
 
+    if (im_data == NULL) {
+        printf("Error: stbi_load failed (Corrupt JPG or Out of Memory)\r\n");
+        return -1;
+    }
+
     /* set nn roi according to image size */
     set_nn_roi(w, h);
 
     /* rgb packed to rgb planar */
     int data_size = w * h * c;
-    uint8_t *rgb_planar_buf = (uint8_t *)malloc(data_size);
+    uint8_t *dest_buf = pImageBuf;
     for (int k = 0; k < c; k++) {
         for (int j = 0; j < h; j++) {
             for (int i = 0; i < w; i++) {
                 int dst_i = i + w * j + w * h * k;
                 int src_i = k + c * i + c * w * j;
-                rgb_planar_buf[dst_i] = im_data[src_i];
+                dest_buf[dst_i] = im_data[src_i];
             }
         }
     }
-    memcpy(pImageBuf, rgb_planar_buf, data_size);
+
     *pImageSize = (uint32_t)data_size;
 
-    free(rgb_planar_buf);
     stbi_image_free(im_data);
 
     return 0;

--- a/Arduino_package/hardware/libraries/NeuralNetwork/src/NNObjectDetectionImage.cpp
+++ b/Arduino_package/hardware/libraries/NeuralNetwork/src/NNObjectDetectionImage.cpp
@@ -226,7 +226,7 @@ int NNObjectDetectionImage::ImageDecodeToRGB888planar_ConvertInPlace(void *pbuff
     }
 
     if (im_data == NULL) {
-        printf("Error: stbi_load failed (Corrupt JPG or Out of Memory)\r\n");
+        amb_ard_printf(ARD_LOG_ERR, "[ERROR] stbi_load failed (Corrupt JPG or Out of Memory)\r\n");
         return -1;
     }
 


### PR DESCRIPTION
## Description of Change
- Feature:
- API Updates: remove second buffer to prevent memory overflow
- Misc:

## Tests and Environments 
- AMB82-mini
- ambpro2_arduino V4.1.0
- Arduino IDE 2.3.7
- Windows 11
