### PR TITLE
Update SPI API for SPI1 switching

### DIFF
--- a/Arduino_package/hardware/libraries/FileSystem/src/AmebaFatFSFile.cpp
+++ b/Arduino_package/hardware/libraries/FileSystem/src/AmebaFatFSFile.cpp
@@ -3,10 +3,10 @@
 
 #ifdef __cplusplus
 extern "C" {
-// #include "helix_mp3_drv.h"
+#include "helix_mp3_drv.h"
 extern void audio_play_binary_array(uint8_t *srcbuf, uint32_t len, uint8_t _audio_vol);
 
-// #include "ota_drv.h"
+#include "ota_drv.h"
 extern void ota_sd(const char *filename);
 }
 #endif

--- a/Arduino_package/hardware/libraries/SPI/examples/Camera_2_Lcd/Camera_2_Lcd.ino
+++ b/Arduino_package/hardware/libraries/SPI/examples/Camera_2_Lcd/Camera_2_Lcd.ino
@@ -35,13 +35,14 @@
 
 #define CHANNEL 0
 
-#define TFT_RESET 5
-#define TFT_DC    4
-#define TFT_CS    SPI_SS
+#define TFT_RESET 5         // You may use other non-conflict pin (e.x.pin 16) if you are using SPI0 for AMB82-zero
+#define TFT_DC    4         // You may use other non-conflict pin (e.x.pin 18) if you are using SPI0 for AMB82-zero
+#define TFT_CS    SPI_SS    // Please change to SPI1_SS if you are using SPI1
+
+AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET);    // SPI0
+// AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET, &SPI1); // SPI1
 
 #define FILENAME "ximg_"
-
-AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET);
 
 #define ILI9341_SPI_FREQUENCY 20000000
 
@@ -77,7 +78,9 @@ void setup()
 
     Serial.println("TFT ILI9341 ");
 
-    SPI.setDefaultFrequency(ILI9341_SPI_FREQUENCY);
+    SPI.setDefaultFrequency(ILI9341_SPI_FREQUENCY);    // SPI0
+    // SPI1.setDefaultFrequency(ILI9341_SPI_FREQUENCY);  // SPI1
+
     pinMode(button, INPUT_IRQ_FALL);
     digitalSetIrqHandler(button, button_Handler);
 

--- a/Arduino_package/hardware/libraries/SPI/examples/Camera_2_Lcd_JPEGDEC/Camera_2_Lcd_JPEGDEC.ino
+++ b/Arduino_package/hardware/libraries/SPI/examples/Camera_2_Lcd_JPEGDEC/Camera_2_Lcd_JPEGDEC.ino
@@ -45,12 +45,12 @@ long lTime;
 
 #define CHANNEL 0
 
-#define TFT_RESET 5
-#define TFT_DC    4
-#define TFT_CS    SPI_SS
+#define TFT_RESET 5         // You may use other non-conflict pin (e.x.pin 16) if you are using SPI0 for AMB82-zero
+#define TFT_DC    4         // You may use other non-conflict pin (e.x.pin 18) if you are using SPI0 for AMB82-zero
+#define TFT_CS    SPI_SS    // Please change to SPI1_SS if you are using SPI1
 
-
-AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET);
+AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET);    // SPI0
+// AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET, &SPI1); // SPI1
 
 #define ILI9341_SPI_FREQUENCY 40000000
 
@@ -73,7 +73,8 @@ void setup()
 
     Serial.println("TFT ILI9341 ");
 
-    SPI.setDefaultFrequency(ILI9341_SPI_FREQUENCY);
+    SPI.setDefaultFrequency(ILI9341_SPI_FREQUENCY);    // SPI0
+    // SPI1.setDefaultFrequency(ILI9341_SPI_FREQUENCY);  // SPI1
 
     Camera.configVideoChannel(CHANNEL, config);
     Camera.videoInit();

--- a/Arduino_package/hardware/libraries/SPI/examples/DisplaySDJPG_ILI9341_TFT/DisplaySDJPG_ILI9341_TFT.ino
+++ b/Arduino_package/hardware/libraries/SPI/examples/DisplaySDJPG_ILI9341_TFT/DisplaySDJPG_ILI9341_TFT.ino
@@ -13,13 +13,14 @@
 #include "TJpg_Decoder.h"
 #include "AmebaFatFS.h"
 
-#define TFT_RESET 5
-#define TFT_DC    4
-#define TFT_CS    SPI_SS
+#define TFT_RESET 5         // You may use other non-conflict pin (e.x.pin 16) if you are using SPI0 for AMB82-zero
+#define TFT_DC    4         // You may use other non-conflict pin (e.x.pin 18) if you are using SPI0 for AMB82-zero
+#define TFT_CS    SPI_SS    // Please change to SPI1_SS if you are using SPI1
+
+AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET);    // SPI0
+// AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET, &SPI1); // SPI1
 
 #define ILI9341_SPI_FREQUENCY 20000000
-
-AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET);
 
 AmebaFatFS fs;
 
@@ -39,7 +40,8 @@ void setup()
 
     Serial.println("TFT ILI9341");
 
-    SPI.setDefaultFrequency(ILI9341_SPI_FREQUENCY);
+    SPI.setDefaultFrequency(ILI9341_SPI_FREQUENCY);    // SPI0
+    // SPI1.setDefaultFrequency(ILI9341_SPI_FREQUENCY);  // SPI1
 
     tft.begin();
     tft.setRotation(0);

--- a/Arduino_package/hardware/libraries/SPI/examples/LCD_Screen_ILI9341_TFT/LCD_Screen_ILI9341_TFT.ino
+++ b/Arduino_package/hardware/libraries/SPI/examples/LCD_Screen_ILI9341_TFT/LCD_Screen_ILI9341_TFT.ino
@@ -18,11 +18,12 @@
 
 // For all supported boards (AMB21/AMB22, AMB23, BW16/BW16-TypeC, AW-CU488_ThingPlus),
 // Select 2 GPIO pins connect to TFT_RESET and TFT_DC. And default SPI_SS/SPI1_SS connect to TFT_CS.
-#define TFT_RESET 5
-#define TFT_DC    4
-#define TFT_CS    SPI_SS
+#define TFT_RESET 5         // You may use other non-conflict pin (e.x.pin 16) if you are using SPI0 for AMB82-zero
+#define TFT_DC    4         // You may use other non-conflict pin (e.x.pin 18) if you are using SPI0 for AMB82-zero
+#define TFT_CS    SPI_SS    // Please change to SPI1_SS if you are using SPI1
 
-AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET);
+AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET);    // SPI0
+// AmebaILI9341 tft = AmebaILI9341(TFT_CS, TFT_DC, TFT_RESET, &SPI1); // SPI1
 
 #define ILI9341_SPI_FREQUENCY 20000000
 
@@ -31,7 +32,8 @@ void setup()
     Serial.begin(115200);
     Serial.println("ILI9341 Test!");
 
-    SPI.setDefaultFrequency(ILI9341_SPI_FREQUENCY);
+    SPI.setDefaultFrequency(ILI9341_SPI_FREQUENCY);    // SPI0
+    // SPI1.setDefaultFrequency(ILI9341_SPI_FREQUENCY);  // SPI1
 
     tft.begin();
 

--- a/Arduino_package/hardware/libraries/SPI/src/AmebaILI9341.cpp
+++ b/Arduino_package/hardware/libraries/SPI/src/AmebaILI9341.cpp
@@ -5,8 +5,9 @@
 
 #include <inttypes.h>
 
-AmebaILI9341::AmebaILI9341(int csPin, int dcPin, int resetPin)
+AmebaILI9341::AmebaILI9341(int csPin, int dcPin, int resetPin, SPIClass *spi)
 {
+    _spi = spi;
     _csPin = csPin;    // TODO: no effect now, use pin 10 as default
     _dcPin = dcPin;
     _resetPin = resetPin;
@@ -33,7 +34,7 @@ void AmebaILI9341::begin(void)
     _dcPort = digitalPinToPort(_dcPin);
     _dcMask = digitalPinToBitMask(_dcPin);
 
-    SPI.begin();
+    _spi->begin();
 
     reset();
 
@@ -169,41 +170,41 @@ void AmebaILI9341::setAddress(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1
 
     //    *portOutputRegister(_dcPort) &= ~(_dcMask);
     digitalWrite(_dcPin, 0);
-    SPI.transfer(ILI9341_CASET);
+    _spi->transfer(ILI9341_CASET);
     //    *portOutputRegister(_dcPort) |=  (_dcMask);
     digitalWrite(_dcPin, 1);
-    SPI.transfer(x >> 8);
-    SPI.transfer(x & 0xFF);
-    SPI.transfer((x + w) >> 8);
-    SPI.transfer((x + w) & 0xFF);
+    _spi->transfer(x >> 8);
+    _spi->transfer(x & 0xFF);
+    _spi->transfer((x + w) >> 8);
+    _spi->transfer((x + w) & 0xFF);
 
     //    *portOutputRegister(_dcPort) &= ~(_dcMask);
     digitalWrite(_dcPin, 0);
-    SPI.transfer(ILI9341_PASET);
+    _spi->transfer(ILI9341_PASET);
     //    *portOutputRegister(_dcPort) |=  (_dcMask);
     digitalWrite(_dcPin, 1);
-    SPI.transfer(y >> 8);
-    SPI.transfer(y & 0xFF);
-    SPI.transfer((y + h) >> 8);
-    SPI.transfer((y + h) & 0xFF);
+    _spi->transfer(y >> 8);
+    _spi->transfer(y & 0xFF);
+    _spi->transfer((y + h) >> 8);
+    _spi->transfer((y + h) & 0xFF);
 
     //    *portOutputRegister(_dcPort) &= ~(_dcMask);
     digitalWrite(_dcPin, 0);
-    SPI.transfer(ILI9341_RAMWR);
+    _spi->transfer(ILI9341_RAMWR);
 }
 
 void AmebaILI9341::writecommand(uint8_t command)
 {
     //    *portOutputRegister(_dcPort) &= ~(_dcMask);
     digitalWrite(_dcPin, 0);
-    SPI.transfer(command);
+    _spi->transfer(command);
 }
 
 void AmebaILI9341::writedata(uint8_t data)
 {
     //    *portOutputRegister(_dcPort) |=  (_dcMask);
     digitalWrite(_dcPin, 1);
-    SPI.transfer(data);
+    _spi->transfer(data);
 }
 
 void AmebaILI9341::setRotation(uint8_t m)
@@ -272,7 +273,7 @@ void AmebaILI9341::drawBitmap(int16_t x, int16_t y, int16_t w, int16_t h, const 
         pPixels[i] = (pPixels[i] << 8) | (pPixels[i] >> 8);
     }
 
-    SPI.transfer(pPixels, pixelCount * 2);
+    _spi->transfer(pPixels, pixelCount * 2);
 }
 
 void AmebaILI9341::fillRectangle(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color)
@@ -301,8 +302,8 @@ void AmebaILI9341::fillRectangle(int16_t x, int16_t y, int16_t w, int16_t h, uin
     //    *portOutputRegister(_dcPort) |=  (_dcMask);
     digitalWrite(_dcPin, 1);
     for (i = 0; i < pixelCount; i++) {
-        SPI.transfer(color_hi);
-        SPI.transfer(color_lo);
+        _spi->transfer(color_hi);
+        _spi->transfer(color_lo);
     }
 }
 
@@ -315,8 +316,8 @@ void AmebaILI9341::drawPixel(int16_t x, int16_t y, uint16_t color)
     setAddress(x, y, (x + 1), (y + 1));
     //    *portOutputRegister(_dcPort) |=  (_dcMask);
     digitalWrite(_dcPin, 1);
-    SPI.transfer(color >> 8);
-    SPI.transfer(color & 0xFF);
+    _spi->transfer(color >> 8);
+    _spi->transfer(color & 0xFF);
 }
 
 void AmebaILI9341::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color)
@@ -359,8 +360,8 @@ void AmebaILI9341::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint
         digitalWrite(_dcPin, 1);
         linelen = abs(y1 - y0);
         for (idx = 0; idx < linelen; idx++) {
-            SPI.transfer(color_hi);
-            SPI.transfer(color_lo);
+            _spi->transfer(color_hi);
+            _spi->transfer(color_lo);
         }
     } else if (y0 == y1) {
         // draw horizontal line
@@ -382,8 +383,8 @@ void AmebaILI9341::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint
         digitalWrite(_dcPin, 1);
         linelen = abs(x1 - x0);
         for (idx = 0; idx < linelen; idx++) {
-            SPI.transfer(color_hi);
-            SPI.transfer(color_lo);
+            _spi->transfer(color_hi);
+            _spi->transfer(color_lo);
         }
     } else {
         // Bresenham's line algorithm

--- a/Arduino_package/hardware/libraries/SPI/src/AmebaILI9341.h
+++ b/Arduino_package/hardware/libraries/SPI/src/AmebaILI9341.h
@@ -92,7 +92,7 @@
 
 class AmebaILI9341: public Print {
 public:
-    AmebaILI9341(int csPin, int dcPin, int resetPin);
+    AmebaILI9341(int csPin, int dcPin, int resetPin, SPIClass *spi = &SPI);
 
     void begin(void);
 
@@ -136,6 +136,7 @@ public:
 private:
     void reset(void);
 
+    SPIClass *_spi;
     int _csPin;
     int _dcPin;
     int _resetPin;

--- a/Arduino_package/hardware/libraries/Wire/examples/I2CMaster_dual/I2CMaster_dual.ino
+++ b/Arduino_package/hardware/libraries/Wire/examples/I2CMaster_dual/I2CMaster_dual.ino
@@ -18,7 +18,8 @@
  Slave address: 0x08
  I2C clock: 100000 Hz (100 kHz)
 
- Example guide: TBD
+ Example guide:
+  https://ameba-doc-arduino-sdk.readthedocs-hosted.com/en/latest/ameba_pro2/amb82-mini/Example_Guides/I2C/Dual%20Board%20I2C%20Master.html
 */
 
 #include <Wire.h>

--- a/Arduino_package/hardware/libraries/Wire/examples/I2CSlave_dual/I2CSlave_dual.ino
+++ b/Arduino_package/hardware/libraries/Wire/examples/I2CSlave_dual/I2CSlave_dual.ino
@@ -17,7 +17,8 @@
 
   Slave address: 0x08
 
-  Example guide: TBD
+  Example guide:
+  https://ameba-doc-arduino-sdk.readthedocs-hosted.com/en/latest/ameba_pro2/amb82-mini/Example_Guides/I2C/Dual%20Board%20I2C%20Slave.html
 */
 
 #include <Wire.h>

--- a/Arduino_package/hardware/libraries/Wire/examples/SlaveReceiveData/SlaveReceiveData.ino
+++ b/Arduino_package/hardware/libraries/Wire/examples/SlaveReceiveData/SlaveReceiveData.ino
@@ -8,7 +8,8 @@
  modified 15 May 2026
  by Realtek SG
 
- Example guide: TBD
+ Example guide:
+ https://ameba-doc-arduino-sdk.readthedocs-hosted.com/en/latest/ameba_pro2/amb82-mini/Example_Guides/I2C/Slave%20Receive%20Data%20from%20Arduino%20UNO.html
 */
 
 #include <Wire.h>

--- a/Arduino_package/hardware/libraries/Wire/examples/SlaveSendData/SlaveSendData.ino
+++ b/Arduino_package/hardware/libraries/Wire/examples/SlaveSendData/SlaveSendData.ino
@@ -8,7 +8,8 @@
  modified 15 May 2026
  by Realtek SG
 
- Example guide: TBD
+ Example guide:
+ https://ameba-doc-arduino-sdk.readthedocs-hosted.com/en/latest/ameba_pro2/amb82-mini/Example_Guides/I2C/Slave%20Send%20Data%20to%20Arduino%20UNO.html
 */
 
 #include <Wire.h>

--- a/Arduino_package/hardware/libraries/Wire/src/Wire.h
+++ b/Arduino_package/hardware/libraries/Wire/src/Wire.h
@@ -44,7 +44,6 @@ public:
     void begin();
     void begin(uint8_t);
     void begin(int);
-    void slaveBegin();
 
     void end();
 


### PR DESCRIPTION
## Description of Change
- Feature:
- API Updates: update SPI api to support SPI0/1 switching
- Misc:

## Tests and Environments 
- AMB82-mini
- ambpro2_arduino V4.1.1
- Arduino IDE 2.3.8
- Windows 11